### PR TITLE
feat: Master gRPC build template with Bazel deps

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,60 +1,48 @@
+# Master BUILD file template for gRPC projects
+# This file should be customized by each project to define its own structure
+# 
+# Example usage:
+# 1. Copy this file to your project
+# 2. Define your proto files location
+# 3. Define your server/client source locations
+# 4. Customize target names as needed
+
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_grpc_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
-# Protocol buffer definition
+# TODO: Replace with your actual proto file paths
+# Example: srcs = glob(["proto/*.proto"]) or srcs = ["my_service.proto"]
 proto_library(
-    name = "helloworld_proto",
-    srcs = glob(["proto/*.proto"]),
+    name = "proto",
+    srcs = [],  # <-- Define your proto files here
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:empty_proto",
+    ],
 )
 
-# Protocol buffer C++ library
+# TODO: Add any additional proto dependencies
+# Example: deps = ["@com_google_protobuf//:any_proto"]
 cc_proto_library(
-    name = "helloworld_cc_proto",
-    deps = [":helloworld_proto"],
+    name = "cc_proto",
+    deps = [":proto"],
 )
 
-# gRPC C++ library - we'll generate this manually for now
-cc_library(
-    name = "helloworld_grpc",
-    srcs = glob(["proto/*.grpc.pb.cc"], allow_empty = True),
-    hdrs = glob(["proto/*.grpc.pb.h"], allow_empty = True),
-    includes = ["proto"],
-    deps = [":helloworld_cc_proto"],
+# TODO: Define your gRPC generated files location
+# Example: Use cpp_grpc_library for automatic generation
+cpp_grpc_library(
+    name = "grpc",
+    protos = [":proto"],
+    deps = [":cc_proto"],
 )
 
-# Server binary with gRPC
-cc_binary(
-    name = "hello_server",
-    srcs = glob(["srv/*.cc"]),
-    deps = [
-        ":helloworld_cc_proto",
-        ":helloworld_grpc",
-    ],
-    copts = [
-        "-std=c++17",
-    ],
-    linkopts = [
-        "-lgrpc++",
-        "-lgrpc",
-        "-lprotobuf",
-        "-lpthread",
-    ],
-)
-
-# Client binary with gRPC
-cc_binary(
-    name = "hello_client",
-    srcs = glob(["cli/*.cc"]),
-    deps = [
-        ":helloworld_cc_proto",
-        ":helloworld_grpc",
-    ],
-    copts = [
-        "-std=c++17",
-    ],
-    linkopts = [
-        "-lgrpc++",
-        "-lgrpc",
-        "-lprotobuf",
-        "-lpthread",
-    ],
-)
+# TODO: Create BUILD files in your server and client directories
+# Example: Create srv/BUILD and cli/BUILD files with cc_binary targets
+# The binaries should depend on the proto libraries defined above:
+#   deps = [":cc_proto", ":grpc"]
+#
+# See BUILD.example for a complete example of how to structure this.

--- a/BUILD.example
+++ b/BUILD.example
@@ -1,0 +1,38 @@
+# Example of how to customize the master BUILD file for a specific project
+# This shows how the current HelloWorldGrpc project would configure the BUILD file
+
+load("@rules_proto_grpc//cpp:defs.bzl", "cpp_grpc_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# Define proto files location for this project
+proto_library(
+    name = "proto",
+    srcs = glob(["proto/*.proto"]),
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:empty_proto",
+    ],
+)
+
+# Protocol buffer C++ library
+cc_proto_library(
+    name = "cc_proto",
+    deps = [":proto"],
+)
+
+# Define gRPC generated files location for this project
+cpp_grpc_library(
+    name = "grpc",
+    protos = [":proto"],
+    deps = [":cc_proto"],
+)
+
+# Note: Server and client binaries are now defined in their respective directories:
+# - srv/BUILD: defines the server binary
+# - cli/BUILD: defines the client binary
+# 
+# This follows Bazel best practices for modular builds.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,23 @@
 module(
-    name = "helloworldgrpc",
+    name = "grpc_project",
     version = "1.0.0",
 )
+
+# External dependencies
+bazel_dep(name = "rules_proto", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "bazel_skylib", version = "1.4.2")
+
+# Protocol Buffers
+bazel_dep(name = "com_google_protobuf", version = "21.12")
+bazel_dep(name = "rules_proto_grpc", version = "4.1.1")
+
+# gRPC dependencies
+bazel_dep(name = "com_github_grpc_grpc", version = "1.50.1")
+bazel_dep(name = "upb", version = "0.0.0-20221230-1.1.0")
+bazel_dep(name = "re2", version = "2022-12-01")
+bazel_dep(name = "abseil-cpp", version = "20220623.1")
+
+# Additional dependencies
+bazel_dep(name = "zlib", version = "1.2.13")
+bazel_dep(name = "c-ares", version = "1.19.1")

--- a/README.md
+++ b/README.md
@@ -27,21 +27,56 @@ HelloWorldGrpc/
 ## Prerequisites
 
 - **Bazel**: Install Bazel (version 6.0+ recommended)
-- **Protocol Buffers**: `protoc` compiler and development libraries
-- **gRPC**: gRPC C++ development libraries and plugins
+- **C++ Compiler**: GCC 9.0+ or Clang with C++17 support
 
-### Ubuntu/Debian Installation
+**Note**: All gRPC and Protocol Buffer dependencies are now managed automatically by Bazel through the `MODULE.bazel` file. No manual installation of system libraries is required!
+
+## Dependencies
+
+### Automatic Dependency Management
+
+All dependencies are now managed automatically by Bazel through the `MODULE.bazel` file. This ensures:
+
+- ✅ **Reproducible builds** across different environments
+- ✅ **No system library conflicts** 
+- ✅ **Automatic version resolution**
+- ✅ **Cross-platform compatibility**
+
+### Bazel Dependencies (Auto-managed)
+
+| Module | Version | Description |
+|--------|---------|-------------|
+| **rules_proto** | 1.0.0 | Protocol buffer rules for Bazel |
+| **rules_cc** | 0.0.9 | C++ rules for Bazel |
+| **bazel_skylib** | 1.4.2 | Skylib utilities for Bazel |
+| **com_google_protobuf** | 21.12 | Protocol Buffers library |
+| **rules_proto_grpc** | 4.1.1 | gRPC protocol buffer rules |
+| **com_github_grpc_grpc** | 1.50.1 | gRPC C++ library |
+| **upb** | 0.0.0-20221230-1.1.0 | Micro protobuf library |
+| **re2** | 2022-12-01 | Regular expression library |
+| **abseil-cpp** | 20220623.1 | Google's C++ common libraries |
+| **zlib** | 1.2.13 | Compression library |
+| **c-ares** | 1.19.1 | Asynchronous DNS resolution library |
+
+### Simple Installation
 
 ```bash
-# Install Bazel
+# Install Bazel only
 curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel-archive-keyring.gpg
 sudo mv bazel-archive-keyring.gpg /usr/share/keyrings
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 sudo apt update && sudo apt install bazel
 
-# Install protobuf and gRPC
-sudo apt install protobuf-compiler libprotobuf-dev libgrpc++-dev protobuf-compiler-grpc
+# Install C++ compiler
+sudo apt install build-essential
 ```
+
+### Version Compatibility
+
+| Bazel | Protobuf | gRPC | C++ Standard |
+|-------|----------|------|--------------|
+| 6.0+  | 21.12    | 1.50.1| C++17        |
+| 7.0+  | 21.12    | 1.50.1| C++17        |
 
 ## Build
 

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -1,0 +1,21 @@
+# Client BUILD file
+# This file defines the client binary target
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+# Client binary with gRPC
+cc_binary(
+    name = "client",
+    srcs = glob(["*.cc"]),
+    deps = [
+        "//:cc_proto",
+        "//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:protobuf",
+    ],
+    copts = [
+        "-std=c++17",
+    ],
+)

--- a/cli/BUILD.example
+++ b/cli/BUILD.example
@@ -1,0 +1,21 @@
+# Example client BUILD file
+# Copy this to cli/BUILD and customize as needed
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+# Client binary with gRPC
+cc_binary(
+    name = "client",
+    srcs = glob(["*.cc"]),
+    deps = [
+        "//:cc_proto",
+        "//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:protobuf",
+    ],
+    copts = [
+        "-std=c++17",
+    ],
+)

--- a/srv/BUILD
+++ b/srv/BUILD
@@ -1,0 +1,21 @@
+# Server BUILD file
+# This file defines the server binary target
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+# Server binary with gRPC
+cc_binary(
+    name = "server",
+    srcs = glob(["*.cc"]),
+    deps = [
+        "//:cc_proto",
+        "//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:protobuf",
+    ],
+    copts = [
+        "-std=c++17",
+    ],
+)

--- a/srv/BUILD.example
+++ b/srv/BUILD.example
@@ -1,0 +1,21 @@
+# Example server BUILD file
+# Copy this to srv/BUILD and customize as needed
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+# Server binary with gRPC
+cc_binary(
+    name = "server",
+    srcs = glob(["*.cc"]),
+    deps = [
+        "//:cc_proto",
+        "//:grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:protobuf",
+    ],
+    copts = [
+        "-std=c++17",
+    ],
+)


### PR DESCRIPTION
- Convert BUILD to generic template (no hardcoded paths/names)
- Add modular BUILD files in cli/ and srv/ directories
- Add complete Bazel dependency management (gRPC 1.50.1, Protobuf 21.12)
- Replace system libs with Bazel-managed externals
- Update README: only need Bazel + compiler, no manual deps
- Create BUILD.example files for project customization

Result: Self-contained, reproducible gRPC project template